### PR TITLE
MES-3066 Updated eyesight fields, made vehicle registration and gearbox type optional

### DIFF
--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-b-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-b-mapper.spec.ts
@@ -46,7 +46,6 @@ describe('mapCatBData', () => {
     };
 
     const expected: DataField[] = [
-      { col: 'EYESIGHT_SERIOUS', val: 0 },
       { col: 'CONTROL_STOP_PROMPT_TOTAL', val: 0 },
       { col: 'REV_RIGHT_TRAIL_CONT_TOTAL', val: 0 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_TOTAL', val: 0 },
@@ -96,6 +95,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_TOTAL', val: 0 },
       { col: 'AWARENESS_PLAN_TOTAL', val: 0 },
       { col: 'ANCILLARY_CONTROLS_TOTAL', val: 0 },
+      { col: 'EYESIGHT_SERIOUS', val: 0 },
       { col: 'CONTROL_STOP_PROMPT_SERIOUS', val: 0 },
       { col: 'REV_RIGHT_TRAIL_CONT_SERIOUS', val: 0 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_SERIOUS', val: 0 },
@@ -194,6 +194,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_DANGEROUS', val: 0 },
       { col: 'AWARENESS_PLAN_DANGEROUS', val: 0 },
       { col: 'ANCILLARY_CONTROLS_DANGEROUS', val: 0 },
+      { col: 'EYESIGHT_COMPLETED', val: 0 },
       { col: 'CONTROL_STOP_COMPLETED', val: 0 },
       { col: 'REV_RIGHT_TRAIL_COMPLETED', val: 0 },
       { col: 'REVERSE_PARK_CARPARK', val: 0 },
@@ -385,8 +386,6 @@ describe('mapCatBData', () => {
           },
           eyesightTest: {
             complete: true,
-            seriousFault: true,
-            faultComments: 'eye sight fault',
           },
         },
         testSummary: {
@@ -396,7 +395,6 @@ describe('mapCatBData', () => {
     };
 
     const expected: DataField[] = [
-      { col: 'EYESIGHT_SERIOUS', val: 1 },
       { col: 'CONTROL_STOP_PROMPT_TOTAL', val: 1 },
       { col: 'REV_RIGHT_TRAIL_CONT_TOTAL', val: 1 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_TOTAL', val: 1 },
@@ -446,6 +444,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_TOTAL', val: 38 },
       { col: 'AWARENESS_PLAN_TOTAL', val: 39 },
       { col: 'ANCILLARY_CONTROLS_TOTAL', val: 40 },
+      { col: 'EYESIGHT_SERIOUS', val: 0 },
       { col: 'CONTROL_STOP_PROMPT_SERIOUS', val: 0 },
       { col: 'REV_RIGHT_TRAIL_CONT_SERIOUS', val: 0 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_SERIOUS', val: 0 },
@@ -544,6 +543,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_DANGEROUS', val: 0 },
       { col: 'AWARENESS_PLAN_DANGEROUS', val: 0 },
       { col: 'ANCILLARY_CONTROLS_DANGEROUS', val: 0 },
+      { col: 'EYESIGHT_COMPLETED', val: 1 },
       { col: 'CONTROL_STOP_COMPLETED', val: 1 },
       { col: 'REV_RIGHT_TRAIL_COMPLETED', val: 1 },
       { col: 'REVERSE_PARK_CARPARK', val: 1 },
@@ -790,7 +790,7 @@ describe('mapCatBData', () => {
           eyesightTest: {
             complete: true,
             seriousFault: true,
-            faultComments: 'eyesight fault',
+            faultComments: 'eyesight serious',
           },
         },
         testSummary: {
@@ -800,7 +800,6 @@ describe('mapCatBData', () => {
     };
 
     const expected: DataField[] = [
-      { col: 'EYESIGHT_SERIOUS', val: 1 },
       { col: 'CONTROL_STOP_PROMPT_TOTAL', val: 0 },
       { col: 'REV_RIGHT_TRAIL_CONT_TOTAL', val: 0 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_TOTAL', val: 0 },
@@ -850,6 +849,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_TOTAL', val: 0 },
       { col: 'AWARENESS_PLAN_TOTAL', val: 0 },
       { col: 'ANCILLARY_CONTROLS_TOTAL', val: 0 },
+      { col: 'EYESIGHT_SERIOUS', val: 1 },
       { col: 'CONTROL_STOP_PROMPT_SERIOUS', val: 1 },
       { col: 'REV_RIGHT_TRAIL_CONT_SERIOUS', val: 1 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_SERIOUS', val: 1 },
@@ -948,6 +948,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_DANGEROUS', val: 0 },
       { col: 'AWARENESS_PLAN_DANGEROUS', val: 0 },
       { col: 'ANCILLARY_CONTROLS_DANGEROUS', val: 0 },
+      { col: 'EYESIGHT_COMPLETED', val: 1 },
       { col: 'CONTROL_STOP_COMPLETED', val: 1 },
       { col: 'REV_RIGHT_TRAIL_COMPLETED', val: 1 },
       { col: 'REVERSE_PARK_CARPARK', val: 1 },
@@ -958,6 +959,7 @@ describe('mapCatBData', () => {
       { col: 'NORMAL_STOP_2_COMPLETED', val: 1 },
       { col: 'ANGLED_START_COMPLETED', val: 1 },
       { col: 'HILL_START_COMPLETED', val: 1 },
+      { col: 'EYESIGHT_COMMENT', val: 'eyesight serious' },
       { col: 'CONTROL_STOP_COMMENT', val: 'controlled stop' },
       { col: 'REV_RIGHT_TRAIL_CONT_COMMENT', val: 'reverse right control' },
       { col: 'REV_RIGHT_TRAIL_OBSERV_COMMENT', val: 'reverse right observation' },
@@ -1192,9 +1194,8 @@ describe('mapCatBData', () => {
             ancillaryControlsComments: 'ancillary controls dangerous',
           },
           eyesightTest: {
-            complete: true,
-            seriousFault: true,
-            faultComments: 'eyesight fault',
+            complete: false,
+            seriousFault: false,
           },
         },
         testSummary: {
@@ -1204,7 +1205,6 @@ describe('mapCatBData', () => {
     };
 
     const expected: DataField[] = [
-      { col: 'EYESIGHT_SERIOUS', val: 1 },
       { col: 'CONTROL_STOP_PROMPT_TOTAL', val: 0 },
       { col: 'REV_RIGHT_TRAIL_CONT_TOTAL', val: 0 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_TOTAL', val: 0 },
@@ -1254,6 +1254,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_TOTAL', val: 0 },
       { col: 'AWARENESS_PLAN_TOTAL', val: 0 },
       { col: 'ANCILLARY_CONTROLS_TOTAL', val: 0 },
+      { col: 'EYESIGHT_SERIOUS', val: 0 },
       { col: 'CONTROL_STOP_PROMPT_SERIOUS', val: 0 },
       { col: 'REV_RIGHT_TRAIL_CONT_SERIOUS', val: 0 },
       { col: 'REV_RIGHT_TRAIL_OBSERV_SERIOUS', val: 0 },
@@ -1352,6 +1353,7 @@ describe('mapCatBData', () => {
       { col: 'POSTITION_STOPS_DANGEROUS', val: 1 },
       { col: 'AWARENESS_PLAN_DANGEROUS', val: 1 },
       { col: 'ANCILLARY_CONTROLS_DANGEROUS', val: 1 },
+      { col: 'EYESIGHT_COMPLETED', val: 0 },
       { col: 'CONTROL_STOP_COMPLETED', val: 1 },
       { col: 'REV_RIGHT_TRAIL_COMPLETED', val: 1 },
       { col: 'REVERSE_PARK_CARPARK', val: 1 },

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
@@ -13,7 +13,7 @@ import { mapCommonData } from '../common-mapper';
 
 describe('mapCommonData', () => {
 
-  // minimally populated pass, manual gearbox, staff number with leading zeros, no gender
+  // minimally populated pass, no gearbox or reg, staff number with leading zeros, no gender
   const minimalInput: ResultUpload = {
     uploadKey: {
       applicationReference: {
@@ -68,10 +68,6 @@ describe('mapCommonData', () => {
         communicationMethod: 'Email',
         conductedLanguage: 'English',
       },
-      vehicleDetails: {
-        registrationNumber: 'DDDDDD',
-        gearboxCategory: 'Manual',
-      },
       testData: {
         faultSummary: {
           totalDrivingFaults: 10,
@@ -87,7 +83,7 @@ describe('mapCommonData', () => {
     },
   };
 
-  it('Should map a minially populated regular test result (pass, manual, english, minimal write up)', () => {
+  it('Should map a minially populated regular test result (pass, no gearbox, english, minimal write up)', () => {
     const expected: DataField[] = [
       { col: 'CHANNEL_INDICATOR', val: ChannelIndicator.MES },
       { col: 'FORM_TYPE', val: FormType.MES },
@@ -129,7 +125,6 @@ describe('mapCommonData', () => {
       { col: 'TEST_CENTRE_ID', val: 1234 },
       { col: 'VEHICLE_SLOT_TYPE', val: 'C' },
       { col: 'WELSH_FORM_IND', val: Language.English },
-      { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
       { col: 'ECO_SAFE_COMPLETED', val: 0 },
       { col: 'ECO_SAFE_CONTROL', val: 0 },
       { col: 'ECO_SAFE_PLANNING', val: 0 },
@@ -304,7 +299,6 @@ describe('mapCommonData', () => {
       { col: 'TEST_CENTRE_ID', val: 1234 },
       { col: 'VEHICLE_SLOT_TYPE', val: 'C' },
       { col: 'WELSH_FORM_IND', val: Language.Welsh },
-      { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
       { col: 'ECO_SAFE_COMPLETED', val: 1 },
       { col: 'ECO_SAFE_CONTROL', val: 1 },
       { col: 'ECO_SAFE_PLANNING', val: 1 },
@@ -315,6 +309,7 @@ describe('mapCommonData', () => {
       { col: 'ADI_NUMBER', val: '555555' },
       { col: 'ETHNICITY', val: 'A' },
       { col: 'GENDER', val: Gender.Female },
+      { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
       { col: 'CANDIDATE_PHYSICAL_DESCRIPTION', val: 'Short' },
       { col: 'WEATHER_CONDITIONS', val: 'Showers|Windy' },
       { col: 'CANDIDATE_IDENTIFICATION', val: 'Passport' },
@@ -477,7 +472,6 @@ describe('mapCommonData', () => {
       { col: 'TEST_CENTRE_ID', val: 1234 },
       { col: 'VEHICLE_SLOT_TYPE', val: 'A' },
       { col: 'WELSH_FORM_IND', val: Language.English },
-      { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
       { col: 'ECO_SAFE_COMPLETED', val: 0 },
       { col: 'ECO_SAFE_CONTROL', val: 0 },
       { col: 'ECO_SAFE_PLANNING', val: 0 },
@@ -487,6 +481,7 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERT_RECEIVED', val: 0 },
       { col: 'ADI_NUMBER', val: '555555' },
       { col: 'GENDER', val: Gender.Male },
+      { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
       { col: 'CANDIDATE_PHYSICAL_DESCRIPTION', val: 'Very tall' },
       { col: 'WEATHER_CONDITIONS', val: 'Showers|Windy' },
       { col: 'CANDIDATE_IDENTIFICATION', val: 'Licence' },
@@ -498,24 +493,24 @@ describe('mapCommonData', () => {
     expect(mapCommonData(input)).toEqual(expected);
   });
 
-  it('Should reject a test result with missing mandatory data (vehicle reg)', () => {
+  it('Should reject a test result with missing mandatory data (candidate forenames)', () => {
     const missingMandatory = cloneDeep(minimalInput);
-    if (missingMandatory.testResult.vehicleDetails) {
-      delete missingMandatory.testResult.vehicleDetails.registrationNumber;
+    if (missingMandatory.testResult.journalData.candidate.candidateName) {
+      delete missingMandatory.testResult.journalData.candidate.candidateName.firstName;
     }
 
     expect(() => mapCommonData(missingMandatory))
-      .toThrow(new MissingTestResultDataError('vehicleDetails.registrationNumber'));
+      .toThrow(new MissingTestResultDataError('journalData.candidate.candidateName.firstName'));
   });
 
-  it('Should reject a test result with missing mandatory data (gearbox category)', () => {
+  it('Should reject a test result with missing mandatory data (candidate date of birth)', () => {
     const missingMandatory = cloneDeep(minimalInput);
-    if (missingMandatory.testResult.vehicleDetails) {
-      delete missingMandatory.testResult.vehicleDetails.gearboxCategory;
+    if (missingMandatory.testResult.journalData.candidate.dateOfBirth) {
+      delete missingMandatory.testResult.journalData.candidate.dateOfBirth;
     }
 
     expect(() => mapCommonData(missingMandatory))
-      .toThrow(new MissingTestResultDataError('testResult.vehicleDetails.gearboxCategory'));
+      .toThrow(new MissingTestResultDataError('testResult.journalData.candidate.dateOfBirth'));
   });
 
   it('Should reject a test result with missing mandatory data (driver number)', () => {

--- a/src/functions/uploadToRSIS/application/data-mapper/cat-b-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/cat-b-mapper.ts
@@ -3,7 +3,6 @@ import { DataField } from '../../domain/mi-export-data';
 import {
   field,
   formatManoeuvreFault,
-  formatEyesightResult,
   formatQuestionFault,
   formatManoeuvreSerious,
   optional,
@@ -27,7 +26,6 @@ export const mapCatBData = (result: ResultUpload): DataField[] => {
   const t = result.testResult.testData;
 
   const m: DataField[] = [
-    field('EYESIGHT_SERIOUS', formatEyesightResult(result)),
     //  unused - H_CODE_SAFETY_TOTAL
     field('CONTROL_STOP_PROMPT_TOTAL', formatManoeuvreFault(t, 'controlledStop.fault')),
     //  unused - CONTROL_STOP_CONTROL_TOTAL
@@ -95,6 +93,7 @@ export const mapCatBData = (result: ResultUpload): DataField[] => {
     //  unused - SPARE3_TOTAL
     //  unused - SPARE4_TOTAL
     //  unused - SPARE5_TOTAL
+    field('EYESIGHT_SERIOUS', optionalBoolean(t, 'eyesightTest.seriousFault')),
     //  unused - H_CODE_SAFETY_SERIOUS
     field('CONTROL_STOP_PROMPT_SERIOUS', formatManoeuvreSerious(t, 'controlledStop.fault')),
     //  unused - CONTROL_STOP_CONTROL_SERIOUS
@@ -231,6 +230,7 @@ export const mapCatBData = (result: ResultUpload): DataField[] => {
     //  unused - SPARE3_DANGEROUS
     //  unused - SPARE4_DANGEROUS
     //  unused - SPARE5_DANGEROUS
+    field('EYESIGHT_COMPLETED', optionalBoolean(t, 'eyesightTest.complete')),
     field('CONTROL_STOP_COMPLETED', optionalBoolean(t, 'controlledStop.selected')),
     //  unused - REV_LEFT_TRAIL_COMPLETED
     field('REV_RIGHT_TRAIL_COMPLETED', optionalBoolean(t, 'manoeuvres.reverseRight.selected')),
@@ -286,6 +286,7 @@ export const mapCatBData = (result: ResultUpload): DataField[] => {
   ];
 
   // add the optional fields, only if set
+  addIfSet(m, 'EYESIGHT_COMMENT', optional(t, 'eyesightTest.faultComments', null));
   addIfSet(m, 'CONTROL_STOP_COMMENT', optional(t, 'controlledStop.faultComments', null));
   addIfSet(m, 'REV_RIGHT_TRAIL_CONT_COMMENT', optional(t, 'manoeuvres.reverseRight.controlFaultComments', null));
   addIfSet(m, 'REV_RIGHT_TRAIL_OBSERV_COMMENT', optional(t, 'manoeuvres.reverseRight.observationFaultComments', null));

--- a/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
@@ -125,7 +125,7 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
     // ETHNICITY is optional field set below
     // unused - COA_LICENCE
     // unused - NO_LICENCE
-    field('VEHICLE_REGISTRATION', mandatory(r, 'vehicleDetails.registrationNumber')),
+    // VEHICLE_REGISTRATION is optional field set below
     field('ECO_SAFE_COMPLETED', optionalBoolean(r, 'testData.eco.completed')),
     field('ECO_SAFE_CONTROL', optionalBoolean(r, 'testData.eco.adviceGivenControl')),
     // unused - ECO_SAFE_COVERED
@@ -142,6 +142,7 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
   addIfSet(mappedFields, 'PASS_CERTIFICATE', optional(r, 'passCompletion.passCertificateNumber', null));
   addIfSet(mappedFields, 'ETHNICITY', optional(r, 'journalData.candidate.ethnicityCode', null));
   addIfSet(mappedFields, 'GENDER', optional(r, 'journalData.candidate.gender', null));
+  addIfSet(mappedFields, 'VEHICLE_REGISTRATION', optional(r, 'vehicleDetails.registrationNumber', null)),
   addIfSet(mappedFields, 'CANDIDATE_PHYSICAL_DESCRIPTION', optional(r, 'testSummary.candidateDescription', null));
   addIfSet(mappedFields, 'WEATHER_CONDITIONS', optional(r, 'testSummary.weatherConditions', []).join('|'));
   addIfSet(mappedFields, 'CANDIDATE_IDENTIFICATION', optional(r, 'testSummary.identification', null));
@@ -153,19 +154,14 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
 };
 
 /**
- * Converts from gearbox category to "is automatic" as a boolean (as a number).
+ * Converts from gearbox category (if any) to "is automatic" as a boolean (as a number).
  *
  * @param result The MES test result
  * @returns ``1`` if automatic, ``0`` otherwise
- * @throws MissingTestResultDataError If vehicle details not set
  */
 const formatGearboxCategory = (result: ResultUpload): BooleanAsNumber => {
-  const gearboxCategory = get(result, 'testResult.vehicleDetails.gearboxCategory', null);
-  if (gearboxCategory) {
-    return gearboxCategory === 'Manual' ? 0 : 1;
-  }
-
-  throw new MissingTestResultDataError('testResult.vehicleDetails.gearboxCategory');
+  const gearboxCategory = get(result, 'testResult.vehicleDetails.gearboxCategory', 'Manual');
+  return gearboxCategory === 'Manual' ? 0 : 1;
 };
 
 /**

--- a/src/functions/uploadToRSIS/application/data-mapper/data-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/data-mapper.ts
@@ -128,18 +128,6 @@ export const mandatory = (object: any, path: string): any => {
 };
 
 /**
- * Formats eyesight result as a number (boolean flag, "is serious fault").
- *
- * @param result The MES test result
- * @returns The result (as a number)
- */
-export const formatEyesightResult = (result: ResultUpload): BooleanAsNumber => {
-  const isEyesightSeriousFault: boolean =
-  get(result, 'testResult.testData.eyesightTest.seriousFault', false);
-  return isEyesightSeriousFault ? 1 : 0;
-};
-
-/**
  * Get the number of faults for the specified manoeuvre, if any.
  *
  * @param object The MES test result


### PR DESCRIPTION
# Description and relevant Jira numbers
Fixed MES-3066 - implementation of the new eyesight fields (eyesight test completed, serious fault, fault comments)
Fixed MES-3112 - vehicle reg and gearbox type (auto/manual) need to be optional, for some types of terminated tests these fields are not completed by the examiner
Tested on dev against RSIS DEV02 (with new eyesight fields)

## Pull Request checklist

- [*] [WIP] tag removed from PR title
- [*] PR has an understandable description

## Git feature branch checklist

- [*] branch name comply with our branching strategy
- [*] git branch contains relevant JIRA ticket number
- [*] branch rebased against the latest develop

## Sign off process checklist

- [*] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA