### PR TITLE
mes-3185 - pass cert number updated schema version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-2.0.2.tgz",
-      "integrity": "sha512-XTxqs8gEbvTJhrtl6Sg0vovmeOQJBWLWNpCcmi2f/ZLO8/4vsRh89RHs3T9FQ39+nZ8WFOnnVsANKKLe/9C7mw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-2.0.3.tgz",
+      "integrity": "sha512-FPwvOkSGsjmyBSIVeJ1GbrKPmJFJ1i4Yea7flcFqK6JtjxttD49/DkdPQV7k3fcSBmLAoXMVUPIibxTuoAR0Mw=="
     },
     "@fimbul/bifrost": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@dvsa/mes-microservice-common": "0.1.4",
-    "@dvsa/mes-test-schema": "2.0.2",
+    "@dvsa/mes-test-schema": "2.0.3",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "axios": "^0.19.0",


### PR DESCRIPTION
Bump `mes-test-schema` version from `2.0.2` to `2.0.3`