### PR TITLE
mes-3185 - pass cert validation bump test version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,9 +138,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-1.0.33.tgz",
-      "integrity": "sha512-SgQ9xlhm2WIMJxMHP2wuoewDHwxuMtiRfYoNCAY5AzqxbpHHwMx3pedui5sKD5T0fHYFMdMO4zNUSgQEe97Q4A=="
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-1.0.35.tgz",
+      "integrity": "sha512-lETOiiNnY/ajOo75NBU0gP41+mVMLMskxcJTen4R0NvqsAqmOI0Bf9KLKvJUcF7ndEpe+ohGaiALEogjnRUnxg=="
     },
     "@fimbul/bifrost": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@dvsa/mes-microservice-common": "0.1.4",
-    "@dvsa/mes-test-schema": "1.0.33",
+    "@dvsa/mes-test-schema": "1.0.35",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "axios": "^0.19.0",


### PR DESCRIPTION
Bump mes-test-schema version to 1.0.35 and updated package lock