### PR TITLE
Mes 3632 bump test schema version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-2.0.3.tgz",
-      "integrity": "sha512-FPwvOkSGsjmyBSIVeJ1GbrKPmJFJ1i4Yea7flcFqK6JtjxttD49/DkdPQV7k3fcSBmLAoXMVUPIibxTuoAR0Mw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.0.0.tgz",
+      "integrity": "sha512-MR4VJR7gsBB5f7rW8d99XAyT8+tlcVJSNDsPjJoeX61WFS1mWN40xyLSO+O8FrpJyXhRSlv+UGDQFjcH4a0T3w=="
     },
     "@fimbul/bifrost": {
       "version": "0.17.0",
@@ -3411,8 +3411,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3433,14 +3432,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3455,20 +3452,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3585,8 +3579,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3598,7 +3591,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3613,7 +3605,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3621,14 +3612,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3647,7 +3636,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3728,8 +3716,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3741,7 +3728,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3827,8 +3813,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3864,7 +3849,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3884,7 +3868,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3928,14 +3911,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@dvsa/mes-microservice-common": "0.1.4",
-    "@dvsa/mes-test-schema": "2.0.3",
+    "@dvsa/mes-test-schema": "3.0.0",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "axios": "^0.19.0",

--- a/src/functions/uploadToRSIS/application/__mocks__/result-uploads.mock.ts
+++ b/src/functions/uploadToRSIS/application/__mocks__/result-uploads.mock.ts
@@ -30,6 +30,7 @@ export const pass: ResultUpload = {
     interfaceType: InterfaceType.RSIS,
   },
   testResult: {
+    version: '0.0.1',
     category: 'B',
     rekey: false,
     rekeyDate: '',
@@ -191,6 +192,7 @@ export const rekeyPass: ResultUpload = {
     interfaceType: InterfaceType.RSIS,
   },
   testResult: {
+    version: '0.0.1',
     category: 'B',
     rekey: true,
     rekeyDate: '',
@@ -364,6 +366,7 @@ export const failAllFaults: ResultUpload = {
     interfaceType: InterfaceType.RSIS,
   },
   testResult: {
+    version: '0.0.1',
     category: 'B',
     rekey: false,
     rekeyDate: '',
@@ -612,6 +615,7 @@ export const failAllSerious: ResultUpload = {
     interfaceType: InterfaceType.RSIS,
   },
   testResult: {
+    version: '0.0.1',
     category: 'B',
     rekey: false,
     rekeyDate: '',
@@ -860,6 +864,7 @@ export const failAllDangerous: ResultUpload = {
     interfaceType: InterfaceType.RSIS,
   },
   testResult: {
+    version: '0.0.1',
     category: 'B',
     rekey: false,
     rekeyDate: '',

--- a/src/functions/uploadToRSIS/application/__tests__/batch-processor.spec.ts
+++ b/src/functions/uploadToRSIS/application/__tests__/batch-processor.spec.ts
@@ -22,6 +22,7 @@ describe('batch-processor', () => {
   const dummyResult1: resultClient.ResultUpload = {
     uploadKey: dummyKey1,
     testResult: {
+      version: '0.0.1',
       category: 'B',
       rekey: false,
       changeMarker: false,

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-b-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-b-mapper.spec.ts
@@ -16,6 +16,7 @@ describe('mapCatBData', () => {
         interfaceType: InterfaceType.RSIS,
       },
       testResult: {
+        version: '0.0.1',
         category: 'B',
         rekey: false,
         changeMarker: false,
@@ -227,6 +228,7 @@ describe('mapCatBData', () => {
         interfaceType: InterfaceType.RSIS,
       },
       testResult: {
+        version: '0.0.1',
         category: 'B',
         rekey: false,
         changeMarker: false,
@@ -634,6 +636,7 @@ describe('mapCatBData', () => {
         interfaceType: InterfaceType.RSIS,
       },
       testResult: {
+        version: '0.0.1',
         category: 'B',
         rekey: false,
         changeMarker: false,
@@ -1044,6 +1047,7 @@ describe('mapCatBData', () => {
         interfaceType: InterfaceType.RSIS,
       },
       testResult: {
+        version: '0.0.1',
         category: 'B',
         rekey: false,
         changeMarker: false,

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
@@ -25,6 +25,7 @@ describe('mapCommonData', () => {
       interfaceType: InterfaceType.RSIS,
     },
     testResult: {
+      version: '0.0.1',
       category: 'B',
       rekey: false,
       changeMarker: false,
@@ -158,6 +159,7 @@ describe('mapCommonData', () => {
         interfaceType: InterfaceType.RSIS,
       },
       testResult: {
+        version: '0.0.1',
         category: 'B',
         rekey: true,
         changeMarker: false,
@@ -345,6 +347,7 @@ describe('mapCommonData', () => {
         interfaceType: InterfaceType.RSIS,
       },
       testResult: {
+        version: '0.0.1',
         category: 'B',
         rekey: false,
         changeMarker: false,

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/data-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/data-mapper.spec.ts
@@ -26,6 +26,7 @@ describe('data mapper', () => {
       interfaceType: InterfaceType.RSIS,
     },
     testResult: {
+      version: '0.0.1',
       category: 'B',
       rekey: false,
       changeMarker: false,


### PR DESCRIPTION
# Description and relevant Jira numbers
Use the latest version of the mes test schema, which includes a new version property: https://github.com/dvsa/mes-api-definitions/pull/75

https://jira.dvsacloud.uk/browse/MES-3632

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA