### PR TITLE
Bug mes 3751 rekey tests not uploading to rsis

### DIFF
--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../domain/mi-export-data';
 import { InterfaceType, ResultUpload } from '../../result-client';
 import { mapCommonData } from '../common-mapper';
+import moment = require('moment');
 
 describe('mapCommonData', () => {
 
@@ -525,7 +526,7 @@ describe('mapCommonData', () => {
       ...minimalInput,
       testResult: {
         ...minimalInput.testResult,
-        rekeyDate: '2019-07-07',
+        rekeyDate: '2019-10-02T11:50:57',
         rekeyReason: {
           other: {
             selected: true,
@@ -593,7 +594,7 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERTIFICATE', val: 'C4444Q' },
       { col: 'COMMUNICATION_METHOD', val: 'Email' },
       { col: 'COMMUNICATION_EMAIL', val: 'still-noone@nowhere.com' },
-      { col: 'REKEY_TIMESTAMP', val: '2019-07-07' },
+      { col: 'REKEY_TIMESTAMP', val: moment('2019-10-02T11:50:57', 'YYYY-MM-DDTHH:mm:ss').toDate() },
       { col: 'REKEY_REASONS', val: 'iPad issue|Other' },
       { col: 'IPAD_ISSUE_REASON', val: 'stolen' },
       { col: 'OTHER_REKEY_REASON', val: 'other reason' },

--- a/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
@@ -26,7 +26,6 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
 
   // test slot start date time from TARS is in local timezone, not UTC
   const testDateTime = moment(r.journalData.testSlotAttributes.start, 'YYYY-MM-DDTHH:mm:ss');
-
   const mappedFields: DataField[] = [
     field('CHANNEL_INDICATOR', r.rekey ? ChannelIndicator.MES_REKEY : ChannelIndicator.MES),
     //  unused - REC_TYPE
@@ -155,7 +154,7 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
   addIfSet(mappedFields, 'COMMUNICATION_METHOD', optional(r, 'communicationPreferences.communicationMethod', null));
   addIfSet(mappedFields, 'COMMUNICATION_EMAIL', optional(r, 'communicationPreferences.updatedEmail', null));
 
-  addIfSet(mappedFields, 'REKEY_TIMESTAMP', optional(r, 'rekeyDate', null));
+  addIfSet(mappedFields, 'REKEY_TIMESTAMP', formatRekeyDateTime(result));
   addIfSet(mappedFields, 'REKEY_REASONS', formatRekeyReason(optional(r, 'rekeyReason', null)));
   addIfSet(mappedFields, 'IPAD_ISSUE_REASON', formatIpadIssueReason(optional(r, 'rekeyReason', null)));
   addIfSet(mappedFields, 'OTHER_REKEY_REASON', optional(r, 'rekeyReason.other.reason', null));
@@ -274,4 +273,18 @@ const formatDateOfBirth = (result: ResultUpload): Date => {
     return moment(dob, 'YYYY-MM-DD').toDate();
   }
   throw new MissingTestResultDataError('testResult.journalData.candidate.dateOfBirth');
+};
+
+/**
+ * Formats the candidate's date of birth.
+ *
+ * @param result The MES test result
+ * @returns The language indicator
+ */
+const formatRekeyDateTime = (result: ResultUpload): Date|null => {
+  const rekeyDateText = get(result, 'testResult.rekeyDate', null);
+  if (rekeyDateText) {
+    return  moment(rekeyDateText,'YYYY-MM-DDTHH:mm:ss').toDate();
+  }
+  return null;
 };

--- a/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
@@ -284,7 +284,7 @@ const formatDateOfBirth = (result: ResultUpload): Date => {
 const formatRekeyDateTime = (result: ResultUpload): Date|null => {
   const rekeyDateText = get(result, 'testResult.rekeyDate', null);
   if (rekeyDateText) {
-    return  moment(rekeyDateText,'YYYY-MM-DDTHH:mm:ss').toDate();
+    return  moment(rekeyDateText, 'YYYY-MM-DDTHH:mm:ss').toDate();
   }
   return null;
 };

--- a/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
@@ -276,10 +276,10 @@ const formatDateOfBirth = (result: ResultUpload): Date => {
 };
 
 /**
- * Formats the candidate's date of birth.
+ * Formats the rekeyDatee
  *
  * @param result The MES test result
- * @returns The language indicator
+ * @returns The formatted date
  */
 const formatRekeyDateTime = (result: ResultUpload): Date|null => {
   const rekeyDateText = get(result, 'testResult.rekeyDate', null);


### PR DESCRIPTION
rekey date was not being formatted in a way oracle could accept.
Have changed  to return a date object that should be compatible.
