### PR TITLE
Removing additonal information check as it may be null

### DIFF
--- a/src/functions/uploadToRSIS/application/result-client.ts
+++ b/src/functions/uploadToRSIS/application/result-client.ts
@@ -174,7 +174,6 @@ export const isRecordAutosaved = (test: StandardCarTestCATBSchema): BooleanAsNum
 
   // We assume that when these properties are null then the test is autosaved
   return (
-    get(test, 'testSummary.additionalInformation', false) &&
       get(test, 'testSummary.candidateDescription', false) &&
       get(test, 'testSummary.identification', false) &&
       get(test, 'testSummary.independentDriving', false) &&


### PR DESCRIPTION
# Description and relevant Jira numbers
- Remove `lodash get` on `additionalInformation` as it has the potential to incorrectly mark tests as `autosaved`
## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA