### PR TITLE
MES-3756 - Fix RSIS username/password mixup

### DIFF
--- a/src/functions/uploadToRSIS/framework/repo/__tests__/database.spec.ts
+++ b/src/functions/uploadToRSIS/framework/repo/__tests__/database.spec.ts
@@ -27,7 +27,11 @@ describe('createConnection', () => {
 
     const conn = await createConnection(useRSISConfig);
 
-    expect(oracledb.getConnection).toHaveBeenCalled();
+    expect(oracledb.getConnection).toHaveBeenCalledWith({
+      user: 'bbb',
+      password: 'ccc',
+      connectString: 'aaa',
+    });
   });
 
   it('Should propogate any exceptions', async () => {

--- a/src/functions/uploadToRSIS/framework/repo/database.ts
+++ b/src/functions/uploadToRSIS/framework/repo/database.ts
@@ -15,7 +15,7 @@ export const createConnection = async (config: Config): Promise<Connection | und
 
     const connection = await getConnection({
       user: config.rsisDatabaseUsername,
-      password: config.rsisDatabaseUsername,
+      password: config.rsisDatabasePassword,
       connectString: connectionString,
     });
     info(`Connection successfully created`);


### PR DESCRIPTION
# Description and relevant Jira numbers
- use configured password when connecting to RSIS oracle database
- added unit tests to catch this issue
- urgent fix made off release-2.1 branch

## Pull Request checklist

- [*] [WIP] tag removed from PR title
- [*] PR has an understandable description

## Git feature branch checklist

- [*] branch name comply with our branching strategy
- [*] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [*] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA