### PR TITLE
MES-3796 - Candidate title and firstname optional in RSIS interface

### DIFF
--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
@@ -14,7 +14,7 @@ import moment = require('moment');
 
 describe('mapCommonData', () => {
 
-  // minimally populated pass, no gearbox or reg, staff number with leading zeros, no gender
+  // minimally populated pass, no gearbox or reg, staff number with leading zeros, no gender, no title, no firstanme
   const minimalInput: ResultUpload = {
     uploadKey: {
       applicationReference: {
@@ -52,8 +52,6 @@ describe('mapCommonData', () => {
         candidate: {
           candidateId: 1111,
           candidateName: {
-            title: 'Mr',
-            firstName: 'BBBBBB',
             lastName: 'AAAAAA',
           },
           candidateAddress: {
@@ -124,11 +122,9 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 1 },
       { col: 'LICENCE_RECEIVED', val: 1 },
       { col: 'DOB', val: new Date('2000-01-31') },
-      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
-      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -307,11 +303,9 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 2 },
       { col: 'LICENCE_RECEIVED', val: 0 },
       { col: 'DOB', val: new Date('2000-01-31') },
-      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
-      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -326,6 +320,8 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERT_RECEIVED', val: 0 },
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'ADI_NUMBER', val: '555555' },
+      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
+      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'ETHNICITY', val: 'A' },
       { col: 'GENDER', val: Gender.Female },
       { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
@@ -489,11 +485,9 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 22 },
       { col: 'LICENCE_RECEIVED', val: 0 },
       { col: 'DOB', val: new Date('2000-01-31') },
-      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
-      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -508,6 +502,8 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERT_RECEIVED', val: 0 },
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'ADI_NUMBER', val: '555555' },
+      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
+      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'GENDER', val: Gender.Male },
       { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
       { col: 'CANDIDATE_PHYSICAL_DESCRIPTION', val: 'Very tall' },
@@ -573,11 +569,9 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 1 },
       { col: 'LICENCE_RECEIVED', val: 1 },
       { col: 'DOB', val: new Date('2000-01-31') },
-      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
-      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -603,16 +597,6 @@ describe('mapCommonData', () => {
     expect(mapCommonData(input)).toEqual(expected);
   });
 
-  it('Should reject a test result with missing mandatory data (candidate forenames)', () => {
-    const missingMandatory = cloneDeep(minimalInput);
-    if (missingMandatory.testResult.journalData.candidate.candidateName) {
-      delete missingMandatory.testResult.journalData.candidate.candidateName.firstName;
-    }
-
-    expect(() => mapCommonData(missingMandatory))
-      .toThrow(new MissingTestResultDataError('journalData.candidate.candidateName.firstName'));
-  });
-
   it('Should reject a test result with missing mandatory data (candidate date of birth)', () => {
     const missingMandatory = cloneDeep(minimalInput);
     if (missingMandatory.testResult.journalData.candidate.dateOfBirth) {
@@ -631,13 +615,13 @@ describe('mapCommonData', () => {
       .toThrow(new MissingTestResultDataError('journalData.candidate.driverNumber'));
   });
 
-  it('Should reject a test result with missing mandatory data (candidate firstname)', () => {
+  it('Should reject a test result with missing mandatory data (candidate lastname)', () => {
     const missingMandatory = cloneDeep(minimalInput);
     if (missingMandatory.testResult.journalData.candidate.candidateName) {
-      delete missingMandatory.testResult.journalData.candidate.candidateName.firstName;
+      delete missingMandatory.testResult.journalData.candidate.candidateName.lastName;
     }
     expect(() => mapCommonData(missingMandatory))
-      .toThrow(new MissingTestResultDataError('journalData.candidate.candidateName.firstName'));
+      .toThrow(new MissingTestResultDataError('journalData.candidate.candidateName.lastName'));
   });
 
   it('Should reject a test result with missing mandatory data (language)', () => {

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
@@ -14,7 +14,7 @@ import moment = require('moment');
 
 describe('mapCommonData', () => {
 
-  // minimally populated pass, no gearbox or reg, staff number with leading zeros, no gender, no title, no firstanme
+  // minimally populated pass, no gearbox or reg, staff number with leading zeros, no gender
   const minimalInput: ResultUpload = {
     uploadKey: {
       applicationReference: {
@@ -52,6 +52,8 @@ describe('mapCommonData', () => {
         candidate: {
           candidateId: 1111,
           candidateName: {
+            title: 'Mr',
+            firstName: 'BBBBBB',
             lastName: 'AAAAAA',
           },
           candidateAddress: {
@@ -122,9 +124,11 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 1 },
       { col: 'LICENCE_RECEIVED', val: 1 },
       { col: 'DOB', val: new Date('2000-01-31') },
+      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
+      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -303,9 +307,11 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 2 },
       { col: 'LICENCE_RECEIVED', val: 0 },
       { col: 'DOB', val: new Date('2000-01-31') },
+      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
+      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -320,8 +326,6 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERT_RECEIVED', val: 0 },
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'ADI_NUMBER', val: '555555' },
-      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
-      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'ETHNICITY', val: 'A' },
       { col: 'GENDER', val: Gender.Female },
       { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
@@ -485,9 +489,11 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 22 },
       { col: 'LICENCE_RECEIVED', val: 0 },
       { col: 'DOB', val: new Date('2000-01-31') },
+      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
+      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -502,8 +508,6 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERT_RECEIVED', val: 0 },
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'ADI_NUMBER', val: '555555' },
-      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
-      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'GENDER', val: Gender.Male },
       { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
       { col: 'CANDIDATE_PHYSICAL_DESCRIPTION', val: 'Very tall' },
@@ -569,9 +573,11 @@ describe('mapCommonData', () => {
       { col: 'ACTIVITY_CODE', val: 1 },
       { col: 'LICENCE_RECEIVED', val: 1 },
       { col: 'DOB', val: new Date('2000-01-31') },
+      { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
       { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
+      { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
       { col: 'TEST_CENTRE_ID', val: 1234 },
@@ -597,6 +603,16 @@ describe('mapCommonData', () => {
     expect(mapCommonData(input)).toEqual(expected);
   });
 
+  it('Should reject a test result with missing mandatory data (candidate forenames)', () => {
+    const missingMandatory = cloneDeep(minimalInput);
+    if (missingMandatory.testResult.journalData.candidate.candidateName) {
+      delete missingMandatory.testResult.journalData.candidate.candidateName.firstName;
+    }
+
+    expect(() => mapCommonData(missingMandatory))
+      .toThrow(new MissingTestResultDataError('journalData.candidate.candidateName.firstName'));
+  });
+
   it('Should reject a test result with missing mandatory data (candidate date of birth)', () => {
     const missingMandatory = cloneDeep(minimalInput);
     if (missingMandatory.testResult.journalData.candidate.dateOfBirth) {
@@ -615,13 +631,13 @@ describe('mapCommonData', () => {
       .toThrow(new MissingTestResultDataError('journalData.candidate.driverNumber'));
   });
 
-  it('Should reject a test result with missing mandatory data (candidate lastname)', () => {
+  it('Should reject a test result with missing mandatory data (candidate firstname)', () => {
     const missingMandatory = cloneDeep(minimalInput);
     if (missingMandatory.testResult.journalData.candidate.candidateName) {
-      delete missingMandatory.testResult.journalData.candidate.candidateName.lastName;
+      delete missingMandatory.testResult.journalData.candidate.candidateName.firstName;
     }
     expect(() => mapCommonData(missingMandatory))
-      .toThrow(new MissingTestResultDataError('journalData.candidate.candidateName.lastName'));
+      .toThrow(new MissingTestResultDataError('journalData.candidate.candidateName.firstName'));
   });
 
   it('Should reject a test result with missing mandatory data (language)', () => {

--- a/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
@@ -89,11 +89,11 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
     // PASS_CERTIFICATE is optional field set below
     field('LICENCE_RECEIVED', optionalBoolean(r, 'passCompletion.provisionalLicenceProvided')),
     field('DOB', formatDateOfBirth(result)),
-    // CANDIDATE_FORENAMES is optional field set below (not populated if DVLA data bad in TARS)
+    field('CANDIDATE_FORENAMES', mandatory(r, 'journalData.candidate.candidateName.firstName')),
     field('CANDIDATE_INDIVIDUAL_ID', mandatory(r, 'journalData.candidate.candidateId')),
     field('CANDIDATE_POST_CODE', mandatory(r, 'journalData.candidate.candidateAddress.postcode')),
     field('CANDIDATE_SURNAME', mandatory(r, 'journalData.candidate.candidateName.lastName')),
-    // CANDIDATE_TITLE is optional field set below (not populated if DVLA data bad in TARS)
+    field('CANDIDATE_TITLE', mandatory(r, 'journalData.candidate.candidateName.title')),
     field('DRIVER_NUMBER', mandatory(r, 'journalData.candidate.driverNumber')),
     // unused - EXAMINER_FORENAMES
     // unused - EXAMINER_PERSON_ID
@@ -145,8 +145,6 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
   // add the optional fields, only if set
   addIfSet(mappedFields, 'ADI_NUMBER', formatInstructorPRN(result));
   addIfSet(mappedFields, 'PASS_CERTIFICATE', optional(r, 'passCompletion.passCertificateNumber', null));
-  addIfSet(mappedFields, 'CANDIDATE_FORENAMES', optional(r, 'journalData.candidate.candidateName.firstName', null)),
-  addIfSet(mappedFields, 'CANDIDATE_TITLE', optional(r, 'journalData.candidate.candidateName.title', null)),
   addIfSet(mappedFields, 'ETHNICITY', optional(r, 'journalData.candidate.ethnicityCode', null));
   addIfSet(mappedFields, 'GENDER', optional(r, 'journalData.candidate.gender', null));
   addIfSet(mappedFields, 'VEHICLE_REGISTRATION', optional(r, 'vehicleDetails.registrationNumber', null)),

--- a/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
@@ -89,11 +89,11 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
     // PASS_CERTIFICATE is optional field set below
     field('LICENCE_RECEIVED', optionalBoolean(r, 'passCompletion.provisionalLicenceProvided')),
     field('DOB', formatDateOfBirth(result)),
-    field('CANDIDATE_FORENAMES', mandatory(r, 'journalData.candidate.candidateName.firstName')),
+    // CANDIDATE_FORENAMES is optional field set below (not populated if DVLA data bad in TARS)
     field('CANDIDATE_INDIVIDUAL_ID', mandatory(r, 'journalData.candidate.candidateId')),
     field('CANDIDATE_POST_CODE', mandatory(r, 'journalData.candidate.candidateAddress.postcode')),
     field('CANDIDATE_SURNAME', mandatory(r, 'journalData.candidate.candidateName.lastName')),
-    field('CANDIDATE_TITLE', mandatory(r, 'journalData.candidate.candidateName.title')),
+    // CANDIDATE_TITLE is optional field set below (not populated if DVLA data bad in TARS)
     field('DRIVER_NUMBER', mandatory(r, 'journalData.candidate.driverNumber')),
     // unused - EXAMINER_FORENAMES
     // unused - EXAMINER_PERSON_ID
@@ -145,6 +145,8 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
   // add the optional fields, only if set
   addIfSet(mappedFields, 'ADI_NUMBER', formatInstructorPRN(result));
   addIfSet(mappedFields, 'PASS_CERTIFICATE', optional(r, 'passCompletion.passCertificateNumber', null));
+  addIfSet(mappedFields, 'CANDIDATE_FORENAMES', optional(r, 'journalData.candidate.candidateName.firstName', null)),
+  addIfSet(mappedFields, 'CANDIDATE_TITLE', optional(r, 'journalData.candidate.candidateName.title', null)),
   addIfSet(mappedFields, 'ETHNICITY', optional(r, 'journalData.candidate.ethnicityCode', null));
   addIfSet(mappedFields, 'GENDER', optional(r, 'journalData.candidate.gender', null));
   addIfSet(mappedFields, 'VEHICLE_REGISTRATION', optional(r, 'vehicleDetails.registrationNumber', null)),


### PR DESCRIPTION
# Description and relevant Jira numbers
* treat candidate title and firstname as optional fields, because sometimes the data from TARS can be empty (if bad data from DVLA, as seen in production)
* only a backend fix
* urgent fix made off release-2.1 branch

## Pull Request checklist

- [*] [WIP] tag removed from PR title
- [*] PR has an understandable description

## Git feature branch checklist

- [*] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [*] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA