### PR TITLE
update to use latest test schema and fix unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.0.0.tgz",
-      "integrity": "sha512-MR4VJR7gsBB5f7rW8d99XAyT8+tlcVJSNDsPjJoeX61WFS1mWN40xyLSO+O8FrpJyXhRSlv+UGDQFjcH4a0T3w=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.2.3.tgz",
+      "integrity": "sha512-DQnQKKOZTo9swch9zvN0DQkOJlluMgjRXFLuRF6qJitl6ArUVlOIERQxrzY4s56mDUkXFAocovnO/HCwHw+lMA=="
     },
     "@fimbul/bifrost": {
       "version": "0.17.0",
@@ -5900,8 +5900,7 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@dvsa/mes-microservice-common": "0.1.4",
-    "@dvsa/mes-test-schema": "3.0.0",
+    "@dvsa/mes-test-schema": "3.2.3",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "axios": "^0.19.0",

--- a/src/functions/uploadToRSIS/application/__tests__/result-client.spec.ts
+++ b/src/functions/uploadToRSIS/application/__tests__/result-client.spec.ts
@@ -1,12 +1,12 @@
 import { isRecordAutosaved } from '../result-client';
-import { StandardCarTestCATBSchema, WeatherConditions } from '@dvsa/mes-test-schema/categories/B';
+import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
 import moment = require('moment');
 
 describe('result-client', () => {
   describe('isRecordAutosaved', () => {
     it('should be an autosave when test summary data not provided', () => {
       // ARRANGE
-      const mockData: Partial<StandardCarTestCATBSchema> = {
+      const mockData: Partial<TestResultSchemasUnion> = {
         category: 'B',
         activityCode: '1',
         journalData: {
@@ -33,12 +33,12 @@ describe('result-client', () => {
       };
 
       // ASSERT
-      expect(isRecordAutosaved(mockData as StandardCarTestCATBSchema)).toBe(1);
+      expect(isRecordAutosaved(mockData as TestResultSchemasUnion)).toBe(1);
     });
 
     describe('test over two weeks old', () => {
       it('should be an autosave with test summary missing', () => {
-        const mockData: Partial<StandardCarTestCATBSchema> = {
+        const mockData: Partial<TestResultSchemasUnion> = {
           category: 'B',
           activityCode: '1',
           journalData: {
@@ -65,11 +65,11 @@ describe('result-client', () => {
         };
 
         // ASSERT
-        expect(isRecordAutosaved(mockData as StandardCarTestCATBSchema)).toBe(1);
+        expect(isRecordAutosaved(mockData as TestResultSchemasUnion)).toBe(1);
       });
 
       it('should be an autosave even with test summary', () => {
-        const mockData: Partial<StandardCarTestCATBSchema> = {
+        const mockData: Partial<TestResultSchemasUnion> = {
           category: 'B',
           activityCode: '1',
           journalData: {
@@ -102,13 +102,13 @@ describe('result-client', () => {
         };
 
         // ASSERT
-        expect(isRecordAutosaved(mockData as StandardCarTestCATBSchema)).toBe(1);
+        expect(isRecordAutosaved(mockData as TestResultSchemasUnion)).toBe(1);
       });
     });
 
     it('should not be an autosave when route number is provided', () => {
       // ARRANGE
-      const mockData: Partial<StandardCarTestCATBSchema> = {
+      const mockData: Partial<TestResultSchemasUnion> = {
         category: 'B',
         activityCode: '1',
         journalData: {
@@ -141,7 +141,7 @@ describe('result-client', () => {
       };
 
       // ASSERT
-      expect(isRecordAutosaved(mockData as StandardCarTestCATBSchema)).toBe(0);
+      expect(isRecordAutosaved(mockData as TestResultSchemasUnion)).toBe(0);
     });
 
   });

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../domain/mi-export-data';
 import { InterfaceType, ResultUpload } from '../../result-client';
 import { mapCommonData } from '../common-mapper';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import moment = require('moment');
 
 describe('mapCommonData', () => {
@@ -73,9 +74,6 @@ describe('mapCommonData', () => {
         conductedLanguage: 'English',
       },
       testData: {
-        faultSummary: {
-          totalDrivingFaults: 10,
-        },
       },
       passCompletion: {
         provisionalLicenceProvided: true,
@@ -112,7 +110,7 @@ describe('mapCommonData', () => {
       { col: 'STAFF_NO', val: '12345678' },
       { col: 'KEYED_STAFF_NO', val: '12345670' },
       { col: 'TEST_RESULT', val: ResultIndicator.Pass },
-      { col: 'TOTAL_FAULTS', val: 10 },
+      { col: 'TOTAL_FAULTS', val: 0 },
       { col: 'ROUTE_NUMBER', val: 15 },
       { col: 'EXAMINER_ACTION_VERBAL', val: 0 },
       { col: 'EXAMINER_ACTION_PHYSICAL', val: 0 },
@@ -147,6 +145,21 @@ describe('mapCommonData', () => {
   });
 
   it('Should map a fully populated regular test result (fail, automatic, welsh, rekey, ethnicity, write up)', () => {
+    const fullTestResult: CatBUniqueTypes.TestData = {
+      eco: {
+        completed: true,
+        adviceGivenControl: true,
+        adviceGivenPlanning: true,
+      },
+      ETA: {
+        physical: true,
+        verbal: true,
+      },
+      eyesightTest: {
+        complete: true,
+      },
+    };
+
     const input: ResultUpload = {
       uploadKey: {
         applicationReference: {
@@ -242,20 +255,7 @@ describe('mapCommonData', () => {
         instructorDetails: {
           registrationNumber: 555555,
         },
-        testData: {
-          eco: {
-            completed: true,
-            adviceGivenControl: true,
-            adviceGivenPlanning: true,
-          },
-          ETA: {
-            physical: true,
-            verbal: true,
-          },
-          faultSummary: {
-            totalDrivingFaults: 20,
-          },
-        },
+        testData: fullTestResult,
         testSummary: {
           routeNumber: 15,
           independentDriving: 'Sat nav',
@@ -293,7 +293,7 @@ describe('mapCommonData', () => {
       { col: 'STAFF_NO', val: '12345678' },
       { col: 'KEYED_STAFF_NO', val: '12345670' },
       { col: 'TEST_RESULT', val: ResultIndicator.Fail },
-      { col: 'TOTAL_FAULTS', val: 20 },
+      { col: 'TOTAL_FAULTS', val: 0 },
       { col: 'ROUTE_NUMBER', val: 15 },
       { col: 'EXAMINER_ACTION_VERBAL', val: 1 },
       { col: 'EXAMINER_ACTION_PHYSICAL', val: 1 },
@@ -337,6 +337,12 @@ describe('mapCommonData', () => {
   });
 
   it('Should map a terminated test result (with defaulted route number, english, vehicle type A, write up)', () => {
+    const terminatedTestResult: CatBUniqueTypes.TestData = {
+      eyesightTest: {
+        complete: true,
+      },
+    };
+
     const input: ResultUpload = {
       uploadKey: {
         applicationReference: {
@@ -431,14 +437,7 @@ describe('mapCommonData', () => {
         instructorDetails: {
           registrationNumber: 555555,
         },
-        testData: {
-          faultSummary: {
-            totalDrivingFaults: 0,
-          },
-          eyesightTest: {
-            complete: true,
-          },
-        },
+        testData: terminatedTestResult,
         testSummary: {
           independentDriving: 'Sat nav',
           debriefWitnessed: true,
@@ -559,7 +558,7 @@ describe('mapCommonData', () => {
       { col: 'STAFF_NO', val: '12345678' },
       { col: 'KEYED_STAFF_NO', val: '12345670' },
       { col: 'TEST_RESULT', val: ResultIndicator.Pass },
-      { col: 'TOTAL_FAULTS', val: 10 },
+      { col: 'TOTAL_FAULTS', val: 0 },
       { col: 'ROUTE_NUMBER', val: 15 },
       { col: 'EXAMINER_ACTION_VERBAL', val: 0 },
       { col: 'EXAMINER_ACTION_PHYSICAL', val: 0 },

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/data-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/data-mapper.spec.ts
@@ -11,7 +11,8 @@ import {
   getCompetencyComments,
 } from '../data-mapper';
 import { cloneDeep } from 'lodash';
-import { QuestionOutcome, VehicleChecks } from '@dvsa/mes-test-schema/categories/B';
+import { QuestionOutcome } from '@dvsa/mes-test-schema/categories/common';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 
 describe('data mapper', () => {
 
@@ -153,7 +154,9 @@ describe('data mapper', () => {
                                      expected: BooleanAsNumber) => {
       const input = cloneDeep(minimalInput);
       if (showMeOutcome || tellMeOutcome) {
-        const vehicleChecks: VehicleChecks = {};
+        // TODO - when new categories are added this will need refactoring
+        //        to populate the different vehicle check types
+        const vehicleChecks: CatBUniqueTypes.VehicleChecks = {};
 
         if (showMeOutcome) {
           vehicleChecks.showMeQuestion = {
@@ -205,7 +208,9 @@ describe('data mapper', () => {
                                        expected: BooleanAsNumber) => {
       const input = cloneDeep(minimalInput);
       if (showMeOutcome || tellMeOutcome) {
-        const vehicleChecks: VehicleChecks = {};
+        // TODO - when new categories are added this will need refactoring
+        //        to populate the different vehicle check types
+        const vehicleChecks: CatBUniqueTypes.VehicleChecks = {};
 
         if (showMeOutcome) {
           vehicleChecks.showMeQuestion = {
@@ -257,7 +262,9 @@ describe('data mapper', () => {
                                          expected: BooleanAsNumber) => {
       const input = cloneDeep(minimalInput);
       if (showMeOutcome || tellMeOutcome) {
-        const vehicleChecks: VehicleChecks = {};
+        // TODO - when new categories are added this will need refactoring
+        //        to populate the different vehicle check types
+        const vehicleChecks: CatBUniqueTypes.VehicleChecks = {};
 
         if (showMeOutcome) {
           vehicleChecks.showMeQuestion = {

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/rekey-reason-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/rekey-reason-mapper.spec.ts
@@ -1,6 +1,6 @@
 
 import { formatIpadIssueReason, formatRekeyReason } from '../rekey-reason-mapper';
-import { RekeyReason } from '@dvsa/mes-test-schema/categories/B';
+import { RekeyReason } from '@dvsa/mes-test-schema/categories/common';
 
 describe('rekey reason mapper', () => {
   describe('formatIpadIssueReason', () => {

--- a/src/functions/uploadToRSIS/application/data-mapper/data-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/data-mapper.ts
@@ -4,7 +4,7 @@ import { ResultUpload } from '../../application/result-client';
 import { mapCommonData } from './common-mapper';
 import { mapCatBData } from './cat-b-mapper';
 import { debug, error } from '@dvsa/mes-microservice-common/application/utils/logger';
-import { ManoeuvreOutcome, TestData, QuestionOutcome } from '@dvsa/mes-test-schema/categories/B';
+import { ManoeuvreOutcome, TestData, QuestionOutcome } from '@dvsa/mes-test-schema/categories/common/';
 
 /**
  * Encapsulates a fatal error caused by mandatory data missing from the MES test result that we are trying to

--- a/src/functions/uploadToRSIS/application/data-mapper/rekey-reason-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/rekey-reason-mapper.ts
@@ -1,5 +1,5 @@
 import { isEmpty, get } from 'lodash';
-import { RekeyReason } from '@dvsa/mes-test-schema/categories/B';
+import { RekeyReason } from '@dvsa/mes-test-schema/categories/common';
 
 /**
  * Checks if there is a reason for rekey, and extracts the iPad issue

--- a/src/functions/uploadToRSIS/application/result-client.ts
+++ b/src/functions/uploadToRSIS/application/result-client.ts
@@ -1,5 +1,6 @@
 import { info, error, debug } from '@dvsa/mes-microservice-common/application/utils/logger';
-import { StandardCarTestCATBSchema, ApplicationReference } from '@dvsa/mes-test-schema/categories/B';
+import { ApplicationReference } from '@dvsa/mes-test-schema/categories/common';
+import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
 import axios, { AxiosError } from 'axios';
 import * as zlib from 'zlib';
 import { formatApplicationReference } from '@dvsa/mes-microservice-common/domain/tars';
@@ -30,7 +31,7 @@ export type UploadKey = {
 
 export type ResultUpload = {
   uploadKey: UploadKey,
-  testResult: StandardCarTestCATBSchema,
+  testResult: TestResultSchemasUnion,
   autosaved: BooleanAsNumber,
 };
 
@@ -71,7 +72,7 @@ export const getNextUploadBatch = async (baseUrl: string, interfaceType: Interfa
       const parseResult = response.data;
       parseResult.forEach((element: string) => {
         let uncompressedResult: string = '';
-        let test: StandardCarTestCATBSchema;
+        let test: TestResultSchemasUnion;
 
         try {
           uncompressedResult = zlib.gunzipSync(new Buffer(element, 'base64')).toString();
@@ -164,7 +165,7 @@ const mapHTTPErrorToDomainError = (err: AxiosError): Error => {
   return new Error(err.message);
 };
 
-export const isRecordAutosaved = (test: StandardCarTestCATBSchema): BooleanAsNumber => {
+export const isRecordAutosaved = (test: TestResultSchemasUnion): BooleanAsNumber => {
   const testDate = moment(new Date(test.journalData.testSlotAttributes.start));
 
   // Two weeks or older is always flagged as autosave


### PR DESCRIPTION
Updated to use latest version of the test schema, and unit tests fixed.

TOTAL_FAULTS had to be adjusted as faultSummary has been removed (and was never populated) so will be raising a separate story to calculate and Populate TOTAL_FAULTS from the driving faults on the test result.