### PR TITLE
MES-5058 make candidate DOB and post code optional fields

### DIFF
--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/common-mapper.spec.ts
@@ -119,9 +119,7 @@ describe('mapCommonData', () => {
       { col: 'DEBRIEF_GIVEN', val: 1 },
       { col: 'ACTIVITY_CODE', val: 1 },
       { col: 'LICENCE_RECEIVED', val: 1 },
-      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
-      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
@@ -137,6 +135,8 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERT_RECEIVED', val: 0 },
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'PASS_CERTIFICATE', val: 'C4444Q' },
+      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
+      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'COMMUNICATION_METHOD', val: 'Email' },
       { col: 'COMMUNICATION_EMAIL', val: 'still-noone@nowhere.com' },
     ];
@@ -301,9 +301,7 @@ describe('mapCommonData', () => {
       { col: 'DEBRIEF_GIVEN', val: 1 },
       { col: 'ACTIVITY_CODE', val: 2 },
       { col: 'LICENCE_RECEIVED', val: 0 },
-      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
-      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
@@ -320,6 +318,8 @@ describe('mapCommonData', () => {
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'ADI_NUMBER', val: '555555' },
       { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
+      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
+      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'ETHNICITY', val: 'A' },
       { col: 'GENDER', val: Gender.Female },
@@ -481,9 +481,7 @@ describe('mapCommonData', () => {
       { col: 'DEBRIEF_GIVEN', val: 1 },
       { col: 'ACTIVITY_CODE', val: 22 },
       { col: 'LICENCE_RECEIVED', val: 0 },
-      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
-      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
@@ -500,6 +498,8 @@ describe('mapCommonData', () => {
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'ADI_NUMBER', val: '555555' },
       { col: 'CANDIDATE_FORENAMES', val: 'BBBBBB' },
+      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
+      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'CANDIDATE_TITLE', val: 'Mr' },
       { col: 'GENDER', val: Gender.Male },
       { col: 'VEHICLE_REGISTRATION', val: 'DDDDDD' },
@@ -564,9 +564,7 @@ describe('mapCommonData', () => {
       { col: 'DEBRIEF_GIVEN', val: 1 },
       { col: 'ACTIVITY_CODE', val: 1 },
       { col: 'LICENCE_RECEIVED', val: 1 },
-      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'CANDIDATE_INDIVIDUAL_ID', val: 1111 },
-      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
       { col: 'CANDIDATE_SURNAME', val: 'AAAAAA' },
       { col: 'DRIVER_NUMBER', val: 'AAAAA111111BB9CC' },
       { col: 'TEST_CATEGORY_REF', val: 'B' },
@@ -582,6 +580,8 @@ describe('mapCommonData', () => {
       { col: 'PASS_CERT_RECEIVED', val: 0 },
       { col: 'NO_WRITE_UP', val: 0 },
       { col: 'PASS_CERTIFICATE', val: 'C4444Q' },
+      { col: 'CANDIDATE_POST_CODE', val: 'AA12 3BB' },
+      { col: 'DOB', val: new Date('2000-01-31') },
       { col: 'COMMUNICATION_METHOD', val: 'Email' },
       { col: 'COMMUNICATION_EMAIL', val: 'still-noone@nowhere.com' },
       { col: 'REKEY_TIMESTAMP', val: moment('2019-10-02T11:50:57', 'YYYY-MM-DDTHH:mm:ss').toDate() },
@@ -591,16 +591,6 @@ describe('mapCommonData', () => {
     ];
 
     expect(mapCommonData(input)).toEqual(expected);
-  });
-
-  it('Should reject a test result with missing mandatory data (candidate date of birth)', () => {
-    const missingMandatory = cloneDeep(minimalInput);
-    if (missingMandatory.testResult.journalData.candidate.dateOfBirth) {
-      delete missingMandatory.testResult.journalData.candidate.dateOfBirth;
-    }
-
-    expect(() => mapCommonData(missingMandatory))
-      .toThrow(new MissingTestResultDataError('testResult.journalData.candidate.dateOfBirth'));
   });
 
   it('Should reject a test result with missing mandatory data (driver number)', () => {

--- a/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/common-mapper.ts
@@ -87,10 +87,10 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
     field('ACTIVITY_CODE', Number(r.activityCode)),
     // PASS_CERTIFICATE is optional field set below
     field('LICENCE_RECEIVED', optionalBoolean(r, 'passCompletion.provisionalLicenceProvided')),
-    field('DOB', formatDateOfBirth(result)),
+    // DOB is optional field set below as found not to always be populated in TARS live
     // CANDIDATE_FORENAMES is optional field set below (not populated if DVLA data bad in TARS)
     field('CANDIDATE_INDIVIDUAL_ID', mandatory(r, 'journalData.candidate.candidateId')),
-    field('CANDIDATE_POST_CODE', mandatory(r, 'journalData.candidate.candidateAddress.postcode')),
+    // CANDIDATE_POST_CODE is optional field set below as found not to always be populated in TARS live
     field('CANDIDATE_SURNAME', mandatory(r, 'journalData.candidate.candidateName.lastName')),
     // CANDIDATE_TITLE is optional field set below (not populated if DVLA data bad in TARS)
     field('DRIVER_NUMBER', mandatory(r, 'journalData.candidate.driverNumber')),
@@ -145,6 +145,8 @@ export const mapCommonData = (result: ResultUpload): DataField[] => {
   addIfSet(mappedFields, 'ADI_NUMBER', formatInstructorPRN(result));
   addIfSet(mappedFields, 'PASS_CERTIFICATE', optional(r, 'passCompletion.passCertificateNumber', null));
   addIfSet(mappedFields, 'CANDIDATE_FORENAMES', optional(r, 'journalData.candidate.candidateName.firstName', null));
+  addIfSet(mappedFields, 'CANDIDATE_POST_CODE', optional(r, 'journalData.candidate.candidateAddress.postcode', null));
+  addIfSet(mappedFields, 'DOB', formatDateOfBirth(result));
   addIfSet(mappedFields, 'CANDIDATE_TITLE', optional(r, 'journalData.candidate.candidateName.title', null));
   addIfSet(mappedFields, 'ETHNICITY', optional(r, 'journalData.candidate.ethnicityCode', null));
   addIfSet(mappedFields, 'GENDER', optional(r, 'journalData.candidate.gender', null));
@@ -260,10 +262,7 @@ const formatLanguage = (result: ResultUpload): Language => {
  */
 const formatDateOfBirth = (result: ResultUpload): Date => {
   const dob = get(result, 'testResult.journalData.candidate.dateOfBirth', null);
-  if (dob) {
-    return moment(dob, 'YYYY-MM-DD').toDate();
-  }
-  throw new MissingTestResultDataError('testResult.journalData.candidate.dateOfBirth');
+  return dob ? moment(dob, 'YYYY-MM-DD').toDate() : dob;
 };
 
 /**


### PR DESCRIPTION
# Description and relevant Jira numbers
- Makes candidate Date of Birth and Post Code optional fields
- Resolves live issue with null fields in TARS data causing validation errors
- Confirmed with TARS / RSIS team these fields are nullable and tested sending null values through

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA