### PR TITLE
make CONTROL_PCV_DOOR_TOTAL optionalBoolean

### DIFF
--- a/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
@@ -55,7 +55,7 @@ export const mapCommonCatDData = (result: ResultUpload): DataField[] => {
     field('CONTROL_STEERING_TOTAL', optional(t, 'drivingFaults.controlsSteering', 0)),
     //  unused - CONTROL_BALANCE_TOTAL
     //  unused - CONTROL_LGV_PCV_GEAR_TOTAL
-    field('CONTROL_PCV_DOOR_TOTAL', optional(t, 'pcvDoorExercise.drivingFault', 0)),
+    field('CONTROL_PCV_DOOR_TOTAL', optionalBoolean(t, 'pcvDoorExercise.drivingFault')),
     field('MOVE_OFF_SAFETY_TOTAL', optional(t, 'drivingFaults.moveOffSafety', 0)),
     field('MOVE_OFF_CONTROL_TOTAL', optional(t, 'drivingFaults.moveOffControl', 0)),
     field('MIRRORS_MC_REAR_SIG_TOTAL', optional(t, 'drivingFaults.useOfMirrorsSignalling', 0)),


### PR DESCRIPTION
MES-5101

RSIS failing for CAT D due to CONTROL_PCV_DOOR_TOTAL being set to true or false (booleans are not supported in oracle) - changing field type to optionalBoolean which converts to 0 or 1.

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number

## Sign off process checklist

- [x] Code has been tested manually
- [x] PR link added to JIRA