### PR TITLE
mes-5110 fix safety question fault count to make binary true false

### DIFF
--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-d-mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-d-mapper.spec.ts
@@ -45,7 +45,7 @@ describe('mapCatDData', () => {
 
     const expected: DataField[] = [
       { col: 'AUTOMATIC_TEST', val: 0 },
-      { col: 'H_CODE_SAFETY_TOTAL', val: 3 },
+      { col: 'H_CODE_SAFETY_TOTAL', val: 1 },
       { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 1 },
       { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 1 },
       { col: 'PRECAUTIONS_TOTAL', val: 2 },

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-d1.mapper.spec.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/cat-d1.mapper.spec.ts
@@ -31,7 +31,7 @@ describe('mapCatD1Data', () => {
 
     const expected: DataField[] = [
       { col: 'AUTOMATIC_TEST', val: 0 },
-      { col: 'H_CODE_SAFETY_TOTAL', val: 3 },
+      { col: 'H_CODE_SAFETY_TOTAL', val: 1 },
       { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 1 },
       { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 1 },
       { col: 'PRECAUTIONS_TOTAL', val: 2 },

--- a/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
@@ -368,8 +368,8 @@ export const getSafetyQuestionFaultCount =
     const faults: boolean[] =
       safetyQuestions.map((questionResult: SafetyQuestionResult) => questionResult.outcome === faultSeverity);
 
-    if (faults) {
-      return faults.length;
+    if (faults && faults.length > 0) {
+      return 1;
     }
     return 0;
   };


### PR DESCRIPTION
# Description and relevant Jira numbers
- Fixes issue with previous PR which made this a count of safety faults rather than 1 / 0 true / false

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA