### PR TITLE
MES-6087: Remove Safety competency mapping for CAT Ds

### DIFF
--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/fully-populated-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/fully-populated-data-fields.ts
@@ -3,7 +3,6 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDFullyPopulatedDrivingDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 1 },
     { col: 'PRECAUTIONS_TOTAL', val: 2 },
@@ -149,7 +148,6 @@ export function getCatDFullyPopulatedDrivingDataFields(): DataField[] {
     { col: 'CONTROL_PARK_COMMENT', val: 'Driving fault comment: controls parking brake fault' },
     { col: 'CONTROL_STEERING_COMMENT', val: 'Driving fault comment: controls steering fault' },
     { col: 'CONTROL_PCV_DOOR_COMMENT', val: 'Driving fault comment: pcv door exercise controls fault' },
-    { col: 'H_CODE_SAFETY_COMMENT', val: 'some comment regarding a fault' },
     { col: 'MOVE_OFF_SAFETY_COMMENT', val: 'Driving fault comment: move off safety fault' },
     { col: 'MOVE_OFF_CONTROL_COMMENT', val: 'Driving fault comment: move off control fault' },
     { col: 'MIRRORS_MC_REAR_SIG_COMMENT', val: 'Driving fault comment: use of mirrors signalling fault' },
@@ -205,7 +203,6 @@ export function getCatDFullyPopulatedDrivingDataFields(): DataField[] {
 export function getCatDFullyPopulatedSeriousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },
@@ -407,7 +404,6 @@ export function getCatDFullyPopulatedSeriousDataFields(): DataField[] {
 export function getCatDFullyPopulatedDangerousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },
@@ -611,10 +607,6 @@ export function getCatDFullyPopulatedDelegatedTest(): DataField[] {
   return [
     {
       col: 'AUTOMATIC_TEST',
-      val: 0,
-    },
-    {
-      col: 'H_CODE_SAFETY_TOTAL',
       val: 0,
     },
     {

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/minimal-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/minimal-data-fields.ts
@@ -3,7 +3,6 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDMinimalDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/fully-populated-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/fully-populated-data-fields.ts
@@ -3,7 +3,6 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDEFullyPopulatedDrivingDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 1 },
     { col: 'PRECAUTIONS_TOTAL', val: 2 },
@@ -202,7 +201,6 @@ export function getCatDEFullyPopulatedDrivingDataFields(): DataField[] {
 export function getCatDEFullyPopulatedSeriousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },
@@ -402,7 +400,6 @@ export function getCatDEFullyPopulatedSeriousDataFields(): DataField[] {
 export function getCatDEFullyPopulatedDangerousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/minimal-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/minimal-data-fields.ts
@@ -3,7 +3,6 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDEMinimalDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
-    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },

--- a/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
@@ -15,9 +15,6 @@ import {
 import { formatGearboxCategoryWithOverride } from '../helpers/shared-formatters';
 import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
 import { get } from 'lodash';
-import { SafetyQuestionResult } from '@dvsa/mes-test-schema/categories/D/partial';
-
-type FaultSeverity = 'DF';
 
 export const mapCommonCatDData = (result: ResultUpload): DataField[] => {
   const t = result.testResult.testData as CatDUniqueTypes.TestData;
@@ -25,7 +22,6 @@ export const mapCommonCatDData = (result: ResultUpload): DataField[] => {
 
   const m: DataField[] = [
     field('AUTOMATIC_TEST', formatGearboxCategoryWithOverride(category, result)),
-    field('H_CODE_SAFETY_TOTAL', getSafetyQuestionFaultCount(t, 'DF')),
     // unused - H_CODE_SAFETY_TOTAL
     // unused - CONTROL_STOP_PROMPT_TOTAL
     // unused - CONTROL_STOP_CONTROL_TOTAL
@@ -286,7 +282,7 @@ export const mapCommonCatDData = (result: ResultUpload): DataField[] => {
   addIfSet(m, 'CONTROL_PARK_COMMENT', getCompetencyComments(t, 'controlsParkingBrakeComments'));
   addIfSet(m, 'CONTROL_STEERING_COMMENT', getCompetencyComments(t, 'controlsSteeringComments'));
   addIfSet(m, 'CONTROL_PCV_DOOR_COMMENT', getPcvDoorExerciseCompetencyComments(t, 'pcvDoorExercise'));
-  addIfSet(m, 'H_CODE_SAFETY_COMMENT', getSafetyQuestionFaultComment(t));
+  // unused - H_CODE_SAFETY_COMMENT
   addIfSet(m, 'MOVE_OFF_SAFETY_COMMENT', getCompetencyComments(t, 'moveOffSafetyComments'));
   addIfSet(m, 'MOVE_OFF_CONTROL_COMMENT', getCompetencyComments(t, 'moveOffControlComments'));
   addIfSet(m, 'MIRRORS_MC_REAR_SIG_COMMENT', getCompetencyComments(t, 'useOfMirrorsSignallingComments'));
@@ -347,20 +343,3 @@ export const getPcvDoorExerciseCompetencyComments =
 
     return getCompetencyCommentString(dangerousComments, seriousComments, faultComments);
   };
-
-export const getSafetyQuestionFaultCount =
-  (testData: CatDUniqueTypes.TestData | undefined, faultSeverity: FaultSeverity): number => {
-
-    const safetyQuestions: SafetyQuestionResult[] = get(testData, 'safetyQuestions.questions', []);
-    const faults: SafetyQuestionResult[] =
-      safetyQuestions.filter((questionResult: SafetyQuestionResult) => questionResult.outcome === faultSeverity);
-
-    if (faults && faults.length > 0) {
-      return 1;
-    }
-    return 0;
-  };
-
-export const getSafetyQuestionFaultComment = (testData: CatDUniqueTypes.TestData | undefined): number => {
-  return get(testData, 'safetyQuestions.faultComments', null);
-};


### PR DESCRIPTION
# Description and relevant Jira numbers

Removing all the safety mappings for cat D, D1, DE, D1E

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA