### PR TITLE
MES-6084: Upgrading mes-test-schema to version 3.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,9 +146,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.29.0.tgz",
-      "integrity": "sha512-mBlEHVfr+zwM2/RLrySY6hiipEu8/8MQXgzISuxun3Ue1FZRDQkcVmuAJw63QvQNu65oMiSgQETYcSTvGqEhZQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.31.0.tgz",
+      "integrity": "sha512-da8ggSPk2rlF0hmmM3TJr4udR+S317XjDU7R2dUi7sYGgv/Si/xk0vJAyEYhkejVqh6xxmJmHng7VnZyIIfXDA==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "oracledb": "^3.1.2"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.29.0",
+    "@dvsa/mes-test-schema": "3.31.0",
     "@types/jasmine": "^2.8.9",
     "@types/node": "^10.12.0",
     "@types/oracledb": "^3.1.2",


### PR DESCRIPTION
Upgrading microservice to use the latest test schema