### PR TITLE
MES-6495: Revert vehicle checks changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,9 +146,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.31.0.tgz",
-      "integrity": "sha512-da8ggSPk2rlF0hmmM3TJr4udR+S317XjDU7R2dUi7sYGgv/Si/xk0vJAyEYhkejVqh6xxmJmHng7VnZyIIfXDA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.29.0.tgz",
+      "integrity": "sha512-mBlEHVfr+zwM2/RLrySY6hiipEu8/8MQXgzISuxun3Ue1FZRDQkcVmuAJw63QvQNu65oMiSgQETYcSTvGqEhZQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "oracledb": "^3.1.2"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.31.0",
+    "@dvsa/mes-test-schema": "3.29.0",
     "@types/jasmine": "^2.8.9",
     "@types/node": "^10.12.0",
     "@types/oracledb": "^3.1.2",

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/fully-populated-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/fully-populated-data-fields.ts
@@ -3,6 +3,7 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDFullyPopulatedDrivingDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 1 },
     { col: 'PRECAUTIONS_TOTAL', val: 2 },
@@ -148,6 +149,7 @@ export function getCatDFullyPopulatedDrivingDataFields(): DataField[] {
     { col: 'CONTROL_PARK_COMMENT', val: 'Driving fault comment: controls parking brake fault' },
     { col: 'CONTROL_STEERING_COMMENT', val: 'Driving fault comment: controls steering fault' },
     { col: 'CONTROL_PCV_DOOR_COMMENT', val: 'Driving fault comment: pcv door exercise controls fault' },
+    { col: 'H_CODE_SAFETY_COMMENT', val: 'some comment regarding a fault' },
     { col: 'MOVE_OFF_SAFETY_COMMENT', val: 'Driving fault comment: move off safety fault' },
     { col: 'MOVE_OFF_CONTROL_COMMENT', val: 'Driving fault comment: move off control fault' },
     { col: 'MIRRORS_MC_REAR_SIG_COMMENT', val: 'Driving fault comment: use of mirrors signalling fault' },
@@ -203,6 +205,7 @@ export function getCatDFullyPopulatedDrivingDataFields(): DataField[] {
 export function getCatDFullyPopulatedSeriousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },
@@ -404,6 +407,7 @@ export function getCatDFullyPopulatedSeriousDataFields(): DataField[] {
 export function getCatDFullyPopulatedDangerousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },
@@ -607,6 +611,10 @@ export function getCatDFullyPopulatedDelegatedTest(): DataField[] {
   return [
     {
       col: 'AUTOMATIC_TEST',
+      val: 0,
+    },
+    {
+      col: 'H_CODE_SAFETY_TOTAL',
       val: 0,
     },
     {

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/minimal-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-d/data-fields/minimal-data-fields.ts
@@ -3,6 +3,7 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDMinimalDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/fully-populated-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/fully-populated-data-fields.ts
@@ -3,6 +3,7 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDEFullyPopulatedDrivingDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 1 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 1 },
     { col: 'PRECAUTIONS_TOTAL', val: 2 },
@@ -201,6 +202,7 @@ export function getCatDEFullyPopulatedDrivingDataFields(): DataField[] {
 export function getCatDEFullyPopulatedSeriousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },
@@ -400,6 +402,7 @@ export function getCatDEFullyPopulatedSeriousDataFields(): DataField[] {
 export function getCatDEFullyPopulatedDangerousDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },

--- a/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/minimal-data-fields.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/__tests__/helpers/cat-de/data-fields/minimal-data-fields.ts
@@ -3,6 +3,7 @@ import { DataField } from '../../../../../../domain/mi-export-data';
 export function getCatDEMinimalDataFields(): DataField[] {
   return [
     { col: 'AUTOMATIC_TEST', val: 0 },
+    { col: 'H_CODE_SAFETY_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_CONT_TOTAL', val: 0 },
     { col: 'REV_LEFT_TRAIL_OBSERV_TOTAL', val: 0 },
     { col: 'PRECAUTIONS_TOTAL', val: 0 },

--- a/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
+++ b/src/functions/uploadToRSIS/application/data-mapper/cat-d-common-mapper.ts
@@ -15,6 +15,9 @@ import {
 import { formatGearboxCategoryWithOverride } from '../helpers/shared-formatters';
 import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
 import { get } from 'lodash';
+import { SafetyQuestionResult } from '@dvsa/mes-test-schema/categories/D/partial';
+
+type FaultSeverity = 'DF';
 
 export const mapCommonCatDData = (result: ResultUpload): DataField[] => {
   const t = result.testResult.testData as CatDUniqueTypes.TestData;
@@ -22,6 +25,7 @@ export const mapCommonCatDData = (result: ResultUpload): DataField[] => {
 
   const m: DataField[] = [
     field('AUTOMATIC_TEST', formatGearboxCategoryWithOverride(category, result)),
+    field('H_CODE_SAFETY_TOTAL', getSafetyQuestionFaultCount(t, 'DF')),
     // unused - H_CODE_SAFETY_TOTAL
     // unused - CONTROL_STOP_PROMPT_TOTAL
     // unused - CONTROL_STOP_CONTROL_TOTAL
@@ -282,7 +286,7 @@ export const mapCommonCatDData = (result: ResultUpload): DataField[] => {
   addIfSet(m, 'CONTROL_PARK_COMMENT', getCompetencyComments(t, 'controlsParkingBrakeComments'));
   addIfSet(m, 'CONTROL_STEERING_COMMENT', getCompetencyComments(t, 'controlsSteeringComments'));
   addIfSet(m, 'CONTROL_PCV_DOOR_COMMENT', getPcvDoorExerciseCompetencyComments(t, 'pcvDoorExercise'));
-  // unused - H_CODE_SAFETY_COMMENT
+  addIfSet(m, 'H_CODE_SAFETY_COMMENT', getSafetyQuestionFaultComment(t));
   addIfSet(m, 'MOVE_OFF_SAFETY_COMMENT', getCompetencyComments(t, 'moveOffSafetyComments'));
   addIfSet(m, 'MOVE_OFF_CONTROL_COMMENT', getCompetencyComments(t, 'moveOffControlComments'));
   addIfSet(m, 'MIRRORS_MC_REAR_SIG_COMMENT', getCompetencyComments(t, 'useOfMirrorsSignallingComments'));
@@ -343,3 +347,20 @@ export const getPcvDoorExerciseCompetencyComments =
 
     return getCompetencyCommentString(dangerousComments, seriousComments, faultComments);
   };
+
+export const getSafetyQuestionFaultCount =
+  (testData: CatDUniqueTypes.TestData | undefined, faultSeverity: FaultSeverity): number => {
+
+    const safetyQuestions: SafetyQuestionResult[] = get(testData, 'safetyQuestions.questions', []);
+    const faults: SafetyQuestionResult[] =
+      safetyQuestions.filter((questionResult: SafetyQuestionResult) => questionResult.outcome === faultSeverity);
+
+    if (faults && faults.length > 0) {
+      return 1;
+    }
+    return 0;
+  };
+
+export const getSafetyQuestionFaultComment = (testData: CatDUniqueTypes.TestData | undefined): number => {
+  return get(testData, 'safetyQuestions.faultComments', null);
+};


### PR DESCRIPTION
# Description and relevant Jira numbers

Reverting commits that contain Vehicle Checks changes

Commits:
- [Mes 6084 Upgrading mes-test-schema to version 3.31.0 (#162)](https://github.com/dvsa/mes-mi-export-service/commit/f925c6c33c89c30a1442f82f1de5dac2b715f546)
- [Mes - 6087 Remove Safety competency mapping for CAT Ds](https://github.com/dvsa/mes-mi-export-service/commit/b1768eda682da049dbac7785cdf0bf69642ab01f)

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA